### PR TITLE
Support for alternative streams + various general improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/gomstreamer.log

--- a/gomstreamer.py
+++ b/gomstreamer.py
@@ -35,7 +35,7 @@ from string import Template
 from urlparse import urljoin
 
 debug = False
-debug = True  # Uncomment this line to print more debugging information
+#debug = True  # Uncomment this line to print more debugging information
 
 # send INFO and above messages to stdout, if debug enabled then also send 
 # everything to 'gomstreamer.log' (because dumps of webpage contents are necessary but distracting)

--- a/gomstreamer.py
+++ b/gomstreamer.py
@@ -34,7 +34,7 @@ from optparse import OptionParser
 from string import Template
 
 debug = True
-debug = False  # Comment this line to print debugging information
+# debug = False  # Comment this line to print debugging information
 
 VERSION = "0.7.0"
 
@@ -154,7 +154,8 @@ def main():
 
     # Collecting data on the Live streaming page
     print 'Getting season url...'
-    gomtvLiveURL = getLivePageURL(gomtvURL)
+    # gomtvLiveURL = getLivePageURL(gomtvURL)
+    gomtvLiveURL = 'http://www.gomtv.net/event/LimJinRok_Live.gom'
     print 'Grabbing the \'Live\' page (%s).' % gomtvLiveURL
     request = urllib2.Request(gomtvLiveURL)
     response = urllib2.urlopen(request)

--- a/gomstreamer.py
+++ b/gomstreamer.py
@@ -34,7 +34,7 @@ from optparse import OptionParser
 from string import Template
 
 debug = True
-# debug = False  # Comment this line to print debugging information
+debug = False  # Comment this line to print debugging information
 
 VERSION = "0.7.0"
 
@@ -154,8 +154,7 @@ def main():
 
     # Collecting data on the Live streaming page
     print 'Getting season url...'
-    # gomtvLiveURL = getLivePageURL(gomtvURL)
-    gomtvLiveURL = 'http://www.gomtv.net/event/LimJinRok_Live.gom'
+    gomtvLiveURL = getLivePageURL(gomtvURL)
     print 'Grabbing the \'Live\' page (%s).' % gomtvLiveURL
     request = urllib2.Request(gomtvLiveURL)
     response = urllib2.urlopen(request)

--- a/linux/play.sh
+++ b/linux/play.sh
@@ -2,4 +2,4 @@
 EMAIL='youremail@example.com'
 PASSWORD='PASSWORD'
 QUALITY='SQTest'
-python ../gomstreamer.py -e $EMAIL -p $PASSWORD -q $QUALITY
+python ../gomstreamer.py -e $EMAIL -p $PASSWORD -q $QUALITY $*

--- a/linux/save.sh
+++ b/linux/save.sh
@@ -4,4 +4,4 @@ PASSWORD='PASSWORD'
 QUALITY='SQTest'
 MODE='save'
 DUMPFILE='dump.ogm'
-python ../gomstreamer.py -e $EMAIL -p $PASSWORD -q $QUALITY -m $MODE -o $DUMPFILE
+python ../gomstreamer.py -e $EMAIL -p $PASSWORD -q $QUALITY -m $MODE -o $DUMPFILE $*

--- a/linux/scheduled-save.sh
+++ b/linux/scheduled-save.sh
@@ -5,4 +5,4 @@ QUALITY='SQTest'
 MODE='scheduled-save'
 KST='18:00'
 DUMPFILE='dump.ogm'
-python ../gomstreamer.py -e $EMAIL -p $PASSWORD -q $QUALITY -m $MODE -t $KST -o $DUMPFILE
+python ../gomstreamer.py -e $EMAIL -p $PASSWORD -q $QUALITY -m $MODE -t $KST -o $DUMPFILE $*

--- a/mac/play.command
+++ b/mac/play.command
@@ -3,4 +3,4 @@ cd "`dirname \"$0\"`"
 EMAIL='youremail@example.com'
 PASSWORD='PASSWORD'
 QUALITY='SQTest'
-python ../gomstreamer.py -e $EMAIL -p $PASSWORD -q $QUALITY
+python ../gomstreamer.py -e $EMAIL -p $PASSWORD -q $QUALITY $*

--- a/mac/save.command
+++ b/mac/save.command
@@ -5,4 +5,4 @@ PASSWORD='PASSWORD'
 QUALITY='SQTest'
 MODE='save'
 DUMPFILE='dump.ogm'
-python ../gomstreamer.py -e $EMAIL -p $PASSWORD -q $QUALITY -m $MODE -o $DUMPFILE
+python ../gomstreamer.py -e $EMAIL -p $PASSWORD -q $QUALITY -m $MODE -o $DUMPFILE $*

--- a/mac/scheduled-save.command
+++ b/mac/scheduled-save.command
@@ -6,4 +6,4 @@ QUALITY='SQTest'
 MODE='scheduled-save'
 KST='18:00'
 DUMPFILE='dump.ogm'
-python ../gomstreamer.py -e $EMAIL -p $PASSWORD -q $QUALITY -m $MODE -t $KST -o $DUMPFILE
+python ../gomstreamer.py -e $EMAIL -p $PASSWORD -q $QUALITY -m $MODE -t $KST -o $DUMPFILE $*

--- a/win/play.cmd
+++ b/win/play.cmd
@@ -1,4 +1,4 @@
 @set EMAIL="youremail@example.com"
 @set PASSWORD="PASSWORD"
 @set QUALITY="SQTest"
-python ..\gomstreamer.py -e %EMAIL% -p %PASSWORD% -q %QUALITY%
+python ..\gomstreamer.py -e %EMAIL% -p %PASSWORD% -q %QUALITY% %*

--- a/win/save.cmd
+++ b/win/save.cmd
@@ -2,4 +2,4 @@
 @set PASSWORD="PASSWORD"
 @set QUALITY="SQTest"
 @set DUMPFILE="dump.ogm"
-python ..\gomstreamer.py -m save -e %EMAIL% -p %PASSWORD% -q %QUALITY% -o %DUMPFILE%
+python ..\gomstreamer.py -m save -e %EMAIL% -p %PASSWORD% -q %QUALITY% -o %DUMPFILE% %*

--- a/win/scheduled-save.cmd
+++ b/win/scheduled-save.cmd
@@ -3,4 +3,4 @@
 @set QUALITY="SQTest"
 @set KST="18:00"
 @set DUMPFILE="dump.ogm"
-python ..\gomstreamer.py -m scheduled-save -e %EMAIL% -p %PASSWORD% -q %QUALITY% -o %DUMPFILE% -t %KST%
+python ..\gomstreamer.py -m scheduled-save -e %EMAIL% -p %PASSWORD% -q %QUALITY% -o %DUMPFILE% -t %KST% %*


### PR DESCRIPTION
Hi!

GOMtv now usually has two code-A streams (for instance, at the moment of writing it's Khaldor on one and Wolf&Doa on another), so I added the ability to select a stream, but in the process got somewhat carried away and touched a lot of code...

So, first of all I finally did the thing that I wanted to do since forever, now there's a generator `iteratePossibleLivePageURLs` that provides possible Live page urls, and a loop that wraps all the following processing in a try/catch block and tries the next url if an error occurs at any point.

Live page url candidates currently are: `/main/goLive.gom`, the target of the 'Live' button on the main page, the contents of the `season.txt` on your server. 

If `-a/--alternative-stream N` is specified, then the 'Live' button is examined first, it might have multiple targets, the N-th is selected (if N > number of targets, then the last one is selected).

While I was working on it I also had to replace all `sys.exit()` calls with (re)throwing of an exception obviously. And add some more try/catch blocks. And while doing that, I decided to channel all output through `logging`, dump all stuff >= logging.INFO to stdout, and all stuff together to `gomstreamer.log` if `debug` is specified. Because raw html dumps were really distracting, but a separate log file without all the stuff that was simply `print`ed was confusing. It's not ideal, it can be improved by adding a custom formatter that would omit stack traces when printing to stdout, but that's not a priority I think.

And that's it, basically. I've checked that it works on most normal paths and some error paths, but not exhaustively, so it would be nice if you read my changes with a fresh eye. Also, I haven't updated the README. Also, I modified all launcher scripts to pass any parameters to the program, so I can use `play.cmd -a 1` for example.
